### PR TITLE
Ability to use view and tables without PK

### DIFF
--- a/libs/NiftyGrid/Grid.php
+++ b/libs/NiftyGrid/Grid.php
@@ -369,7 +369,7 @@ abstract class Grid extends \Nette\Application\UI\Control
 	protected function setDataSource(DataSource\IDataSource $dataSource)
 	{
 		$this->dataSource = $dataSource;
-		$this->primaryKey = $this->dataSource->getPrimaryKey();
+		//$this->primaryKey = $this->dataSource->getPrimaryKey();
 	}
 
 	/**


### PR DESCRIPTION
When setting datasource the primary key was always forced which resulted in unability to use table without PK(views).
